### PR TITLE
Add chinese config and disable C2K

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -124,7 +124,7 @@ REPLACE="
 print_modname() {
   ui_print "******************************"
   ui_print "*                            *"
-  ui_print "*      GLOBAL OPTIMIZED      *"
+  ui_print "*      Chinese OPTIMIZED     *"
   ui_print "*      GPS FILE REPLACER     *"
   ui_print "*                            *"
   ui_print "*       by ianhughes74       *"
@@ -149,7 +149,12 @@ on_install() {
   # The following is the default implementation: extract $ZIPFILE/system to $MODPATH
   # Extend/change the logic to whatever you want
   ui_print "- Extracting module files"
-  unzip -o "$ZIPFILE" 'system/*' -d $MODPATH >&2
+  if $(getprop gsm.operator.iso-country) = '[gsm.operator.iso-country]: [cn]';then
+    unzip -o "$ZIPFILE" 'system_china/*' -d $MODPATH >&2
+    settings put global ntp_server cn.ntp.org.cn
+  else
+    unzip -o "$ZIPFILE" 'system/*' -d $MODPATH >&2
+  fi
 }
 
 # Only some special files require specific permissions

--- a/install.sh
+++ b/install.sh
@@ -149,8 +149,8 @@ on_install() {
   # The following is the default implementation: extract $ZIPFILE/system to $MODPATH
   # Extend/change the logic to whatever you want
   ui_print "- Extracting module files"
-  if [[ $(getprop gsm.operator.iso-country) = '[gsm.operator.iso-country]: [cn]' ]];then
-    unzip -o "$ZIPFILE" 'system_china/*' -d $MODPATH >&2
+  if [[ $(getprop gsm.operator.iso-country) = 'cn,cn' ]];then
+    unzip -o "$ZIPFILE" 'system_CN/*' -d $MODPATH >&2
     settings put global ntp_server cn.ntp.org.cn
   else
     unzip -o "$ZIPFILE" 'system/*' -d $MODPATH >&2

--- a/install.sh
+++ b/install.sh
@@ -124,7 +124,7 @@ REPLACE="
 print_modname() {
   ui_print "******************************"
   ui_print "*                            *"
-  ui_print "*      Chinese OPTIMIZED     *"
+  ui_print "*      GLOBAL OPTIMIZED      *"
   ui_print "*      GPS FILE REPLACER     *"
   ui_print "*                            *"
   ui_print "*       by ianhughes74       *"

--- a/install.sh
+++ b/install.sh
@@ -149,7 +149,7 @@ on_install() {
   # The following is the default implementation: extract $ZIPFILE/system to $MODPATH
   # Extend/change the logic to whatever you want
   ui_print "- Extracting module files"
-  if $(getprop gsm.operator.iso-country) = '[gsm.operator.iso-country]: [cn]';then
+  if [[ $(getprop gsm.operator.iso-country) = '[gsm.operator.iso-country]: [cn]' ]];then
     unzip -o "$ZIPFILE" 'system_china/*' -d $MODPATH >&2
     settings put global ntp_server cn.ntp.org.cn
   else

--- a/system/etc/gps.conf
+++ b/system/etc/gps.conf
@@ -16,7 +16,6 @@ XTRA_SERVER_1 = https://xtrapath1.izatcloud.net/xtra3grc.bin
 XTRA_SERVER_2 = https://xtrapath2.izatcloud.net/xtra3grc.bin
 XTRA_SERVER_3 = https://xtrapath3.izatcloud.net/xtra3grc.bin
 XTRA_SERVER_4 = https://ssl.gpsonextra.net/xtra3grc.bin
-XTRA_SERVER_5 = https://ssl.izatcloud.net/xtra3grc.bin
 
 # Whether or not to test for XTRA support.
 #
@@ -50,11 +49,10 @@ ERR_ESTIMATE = 0
 # The NTP servers used for time synchronisation.
 #
 # Values: URL
-NTP_SERVER = rhel.pool.ntp.org
-NTP_SERVER_1 = 0.rhel.pool.ntp.org
-NTP_SERVER_2 = 1.rhel.pool.ntp.org
-NTP_SERVER_3 = 2.rhel.pool.ntp.org
-NTP_SERVER_4 = 3.rhel.pool.ntp.org
+NTP_SERVER = pool.ntp.org
+NTP_SERVER_1 = time.google.com
+NTP_SERVER_2 = time.apple.com
+NTP_SERVER_3 = time.windows.com
 
 ##################################################
 # Debugging
@@ -79,7 +77,7 @@ INTERMEDIATE_POS = 1
 # Set to 0 to pass all positions.
 #
 # Values: unknown
-ACCURACY_THRES = 0
+ACCURACY_THRES = 1
 
 ##################################################
 # 
@@ -164,12 +162,12 @@ ENABLE_WIPER = 1
 # The C2K PDE server used.
 #
 # Values: URL, IP
-C2K_HOST = c2k.pde.com
+#C2K_HOST = c2k.pde.com
 
 # The port to connect to the C2K PDE server.
 #
 # Values: port
-C2K_PORT = 1234
+#C2K_PORT = 1234
 
 ##################################################
 # A-GPS settings

--- a/system/vendor/etc/gps.conf
+++ b/system/vendor/etc/gps.conf
@@ -16,7 +16,6 @@ XTRA_SERVER_1 = https://xtrapath1.izatcloud.net/xtra3grc.bin
 XTRA_SERVER_2 = https://xtrapath2.izatcloud.net/xtra3grc.bin
 XTRA_SERVER_3 = https://xtrapath3.izatcloud.net/xtra3grc.bin
 XTRA_SERVER_4 = https://ssl.gpsonextra.net/xtra3grc.bin
-XTRA_SERVER_5 = https://ssl.izatcloud.net/xtra3grc.bin
 
 # Whether or not to test for XTRA support.
 #
@@ -50,11 +49,10 @@ ERR_ESTIMATE = 0
 # The NTP servers used for time synchronisation.
 #
 # Values: URL
-NTP_SERVER = rhel.pool.ntp.org
-NTP_SERVER_1 = 0.rhel.pool.ntp.org
-NTP_SERVER_2 = 1.rhel.pool.ntp.org
-NTP_SERVER_3 = 2.rhel.pool.ntp.org
-NTP_SERVER_4 = 3.rhel.pool.ntp.org
+NTP_SERVER = pool.ntp.org
+NTP_SERVER_1 = time.google.com
+NTP_SERVER_2 = time.apple.com
+NTP_SERVER_3 = time.windows.com
 
 ##################################################
 # Debugging
@@ -79,7 +77,7 @@ INTERMEDIATE_POS = 1
 # Set to 0 to pass all positions.
 #
 # Values: unknown
-ACCURACY_THRES = 0
+ACCURACY_THRES = 1
 
 ##################################################
 # 
@@ -164,12 +162,12 @@ ENABLE_WIPER = 1
 # The C2K PDE server used.
 #
 # Values: URL, IP
-C2K_HOST = c2k.pde.com
+#C2K_HOST = c2k.pde.com
 
 # The port to connect to the C2K PDE server.
 #
 # Values: port
-C2K_PORT = 1234
+#C2K_PORT = 1234
 
 ##################################################
 # A-GPS settings


### PR DESCRIPTION
Chinese network environment is special and requires special configuration to reduce latency for more accurate results.
Through [ipip.net](https://tools.ipip.net/ping.php) test,pool.ntp.org isn't the best in some area,so I add some company's ntp server.
C2K is only for developer,there isn't the domain name,so there is no reason to enable it.
I changed `ACCURACY_THRES` to 1 to prevent positional deviations from being too large (eg 100KM).
I also deleted some invalid server.