### PR TITLE
rhel.pool.ntp.org is a non-existent domain.

### DIFF
--- a/system/etc/gps.conf
+++ b/system/etc/gps.conf
@@ -50,11 +50,10 @@ ERR_ESTIMATE = 0
 # The NTP servers used for time synchronisation.
 #
 # Values: URL
-NTP_SERVER = rhel.pool.ntp.org
-NTP_SERVER_1 = 0.rhel.pool.ntp.org
-NTP_SERVER_2 = 1.rhel.pool.ntp.org
-NTP_SERVER_3 = 2.rhel.pool.ntp.org
-NTP_SERVER_4 = 3.rhel.pool.ntp.org
+NTP_SERVER = 0.rhel.pool.ntp.org
+NTP_SERVER_1 = 1.rhel.pool.ntp.org
+NTP_SERVER_2 = 2.rhel.pool.ntp.org
+NTP_SERVER_3 = 3.rhel.pool.ntp.org
 
 ##################################################
 # Debugging

--- a/system/vendor/etc/gps.conf
+++ b/system/vendor/etc/gps.conf
@@ -50,11 +50,10 @@ ERR_ESTIMATE = 0
 # The NTP servers used for time synchronisation.
 #
 # Values: URL
-NTP_SERVER = rhel.pool.ntp.org
-NTP_SERVER_1 = 0.rhel.pool.ntp.org
-NTP_SERVER_2 = 1.rhel.pool.ntp.org
-NTP_SERVER_3 = 2.rhel.pool.ntp.org
-NTP_SERVER_4 = 3.rhel.pool.ntp.org
+NTP_SERVER = 0.rhel.pool.ntp.org
+NTP_SERVER_1 = 1.rhel.pool.ntp.org
+NTP_SERVER_2 = 2.rhel.pool.ntp.org
+NTP_SERVER_3 = 3.rhel.pool.ntp.org
 
 ##################################################
 # Debugging

--- a/system_CN/etc/gps.conf
+++ b/system_CN/etc/gps.conf
@@ -50,7 +50,7 @@ ERR_ESTIMATE = 0
 # The NTP servers used for time synchronisation.
 #
 # Values: URL
-NTP_SERVER = rhel.pool.ntp.org
+NTP_SERVER = 0.rhel.pool.ntp.org
 NTP_SERVER_1 = ntp.neusoft.edu.cn
 NTP_SERVER_2 = ntp.neu6.edu.cn
 NTP_SERVER_3 = ntp.synet.edu.cn

--- a/system_CN/vendor/etc/gps.conf
+++ b/system_CN/vendor/etc/gps.conf
@@ -50,7 +50,7 @@ ERR_ESTIMATE = 0
 # The NTP servers used for time synchronisation.
 #
 # Values: URL
-NTP_SERVER = rhel.pool.ntp.org
+NTP_SERVER = 0.rhel.pool.ntp.org
 NTP_SERVER_1 = ntp.neusoft.edu.cn
 NTP_SERVER_2 = ntp.neu6.edu.cn
 NTP_SERVER_3 = ntp.synet.edu.cn


### PR DESCRIPTION
rhel.pool.ntp.org is a non-existent domain, which was also specified as the first server that makes this module no-so-optimised-but-mush-worse-gps-conf.